### PR TITLE
New feature: Add social icons in footer

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -20,6 +20,14 @@ googleAnalytics = ""  # add your tracking id
     avatarSize = "90px"
     colorBlack = "#222222"
     colorRed = "#dc3545"
+  [[params.socialIcons]]
+    icon = "fab fa-twitter"
+    title = "Twitter"
+    url = "https://twitter.com/"
+  [[params.socialIcons]]
+    icon = "fas fa-envelope"
+    title = "E-mail"
+    url = "mailto:mail@example.com"
 
 [permalinks]
   "/" = "/:filename"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,7 +2,7 @@
     <hr>
     <div class="container text-center">
         {{ range $item := .Site.Params.socialIcons }}
-            <a href="{{ $item.url }}" class="{{ $item.icon }} fa-1x"></a>
+            <a href="{{ $item.url }}" class="{{ $item.icon }} fa-1x" title="{{ $item.title }}"></a>
         {{ end }}
     </div>
     {{ with .Site.Params.footer }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,11 @@
 <div id="footer" class="mb-5">
+    <hr>
+    <div class="container text-center">
+        {{ range $item := .Site.Params.socialIcons }}
+            <a href="{{ $item.url }}" class="{{ $item.icon }} fa-1x"></a>
+        {{ end }}
+    </div>
     {{ with .Site.Params.footer }}
-        <hr>
         <div class="container text-center">
             <a href="{{ .url | absURL }}" title="{{ .text }}"><small>{{ .text }}</small></a>
         </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,6 +8,7 @@
 
     <link href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css" integrity="sha512-iBBXm8fW90+nuLcSKlbmrPcLa0OT92xO1BIsZ+ywDWZCvqsWgccV3gFoRBv0z+8dLJgyAHIhR35VZc2oM/gI1w==" crossorigin="anonymous">
 
     {{ $style := resources.Get "sass/researcher.scss" | resources.ExecuteAsTemplate "sass/researcher.scss" . | toCSS | minify }}
     <link rel="stylesheet" href="{{ $style.RelPermalink }}">


### PR DESCRIPTION
With this PR I add a new parameter `socialIcons` to `params`. Setting this parameters you can add social icons in the website footer. I've updated `config.toml` in order to show how to do that.