### PR TITLE
Keep indent of ol and ul to make multiple lines looks better

### DIFF
--- a/assets/sass/researcher.scss
+++ b/assets/sass/researcher.scss
@@ -91,9 +91,15 @@ $y-medium: 1.0rem;
         counter-reset: list;
         list-style: none;
         padding-left: 2rem;
+        & > li {
+            display: table-row;
+        }
         & > li:before {
             content: "[" counter(list, decimal) "] ";
             counter-increment: list;
+            display: table-cell;
+            text-align: right;
+            padding-right: .5em;
         }
     }
     .container > ol, .footnotes > ol {
@@ -102,6 +108,10 @@ $y-medium: 1.0rem;
     ul {
         list-style: inside;
         padding-left: 2rem;
+        & > li {
+            list-style-position: outside;
+            margin-left: 1em;
+        }
     }
     .container > ul, .footnotes > ul {
         padding-left: 0;


### PR DESCRIPTION
Useful when listing publications.
```
# test doc

1. aaaaaa </br> bbbbbb
1. aaaaaa </br> bbbbbb
1. aaaaaa </br> bbbbbb

* aaaaaa </br> bbbbbb
* aaaaaa </br> bbbbbb
* aaaaaa </br> bbbbbb
```
![rendered](https://user-images.githubusercontent.com/12966475/121628008-03fc0b00-caab-11eb-8543-c96a43776fe9.png)
