### PR TITLE
Add support for Academicicons

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -29,6 +29,10 @@ googleAnalytics = ""  # add your tracking id
     icon = "fas fa-envelope"
     title = "E-mail"
     url = "mailto:mail@example.com"
+  [[params.socialIcons]]
+    icon = "ai ai-google-scholar"
+    title = "Scholar"
+    url = "https://scholar.google.com/"
 
 [permalinks]
   "/" = "/:filename"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,6 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css" integrity="sha512-iBBXm8fW90+nuLcSKlbmrPcLa0OT92xO1BIsZ+ywDWZCvqsWgccV3gFoRBv0z+8dLJgyAHIhR35VZc2oM/gI1w==" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/jpswalsh/academicons@1/css/academicons.min.css">
 
     {{ $style := resources.Get "sass/researcher.scss" | resources.ExecuteAsTemplate "sass/researcher.scss" . | toCSS | minify }}
     <link rel="stylesheet" href="{{ $style.RelPermalink }}">


### PR DESCRIPTION
Font Awesome does not include some academic icons, for instance Scholar. In a Researcher theme having them is quite useful, so I propose adding support for Academicicons.