### PR TITLE
Add option to ask crawlers to not index a page

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -25,4 +25,8 @@
     {{ if not .Site.IsServer }}
         {{ template "_internal/google_analytics.html" . }}
     {{ end }}
+
+    {{ if .Params.noindex }}
+        <meta name="robots" content="noindex">
+    {{ end }}
 </head>


### PR DESCRIPTION
With this commit, pages can be marked as "noindex" to avoid indexing from search engines. To activate this tag on a give page, the option `noindex` has to be set true at the beginning on the markdown file, as in:

```
+++
title = "Example"
noindex = true
+++
```