### PR TITLE
Updated for Hugo 0.134.0

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -11,7 +11,7 @@
         </div>
         {{- partial "footer.html" . -}}
 
-        {{ if and (not .Site.IsServer) .Site.Data.consent }}
+        {{ if and (not hugo.IsServer) .Site.Data.consent }}
         {{- partial "consent.html" . -}}
         {{ end }}
     </body>

--- a/layouts/partials/googleanalytics.html
+++ b/layouts/partials/googleanalytics.html
@@ -1,5 +1,5 @@
 {{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
-{{- if not $pc.Disable }}{{ with .Site.GoogleAnalytics -}}
+{{- if not $pc.Disable }}{{ with .Site.Config.Services.GoogleAnalytics.ID -}}
 <script>
 {{- if not $pc.RespectDoNotTrack -}}
 var doNotTrack = false;

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -20,7 +20,7 @@
         {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
     {{ end -}}
 
-    {{- if not .Site.IsServer -}}
+    {{- if not hugo.IsServer -}}
         {{- partial "googleanalytics.html" . -}}
     {{- end -}}
 


### PR DESCRIPTION
Updated to resolve the following errors:

```
ERROR deprecated: .Site.IsServer was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.134.0. Use hugo.IsServer instead.
ERROR deprecated: .Site.GoogleAnalytics was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.134.0. Use .Site.Config.Services.GoogleAnalytics.ID instead.
```